### PR TITLE
bug fixed allowing Body to be specified with omega

### DIFF
--- a/transit/transit.py
+++ b/transit/transit.py
@@ -210,7 +210,7 @@ class Body(object):
         assert pomega is None or omega is None, \
             "You can't specify omega and pomega"
         if omega is not None:
-            self.omega = omega
+            self.pomega = 0.5 * np.pi - omega
         elif pomega is not None:
             self.pomega = pomega
         else:
@@ -365,7 +365,7 @@ class Body(object):
 
     @omega.setter
     def omega(self, v, hp=0.5*np.pi):
-        self.pomga = v - hp
+        self.pomega = v - hp
 
 
 class System(object):

--- a/transit/transit.py
+++ b/transit/transit.py
@@ -210,7 +210,7 @@ class Body(object):
         assert pomega is None or omega is None, \
             "You can't specify omega and pomega"
         if omega is not None:
-            self.pomega = 0.5 * np.pi - omega
+            self.omega = omega
         elif pomega is not None:
             self.pomega = pomega
         else:


### PR DESCRIPTION
For a body, if `omega` is provided, now just `self.pomega` is set, leaving `omega` as a derived property.
