### PR TITLE
adding a duration_approx property, and added dilution to System

### DIFF
--- a/transit/transit.py
+++ b/transit/transit.py
@@ -400,11 +400,14 @@ class System(object):
 
     """
 
-    def __init__(self, central, iobs=90.0):
+    def __init__(self, central, iobs=90.0, dilution=0.):
         self.central = central
         self.central.system = self
         self.bodies = []
         self.iobs = iobs
+
+        assert 0 <= dilution < 1, 'Dilution must be between 0 and 1!'
+        self.dilution = dilution
 
     def __len__(self):
         return len(self.bodies)
@@ -453,7 +456,14 @@ class System(object):
         t = np.atleast_1d(t)
 
         # Compute the light curve using the Kepler solver.
-        return self._get_solver().light_curve(s.flux, t, texp, tol, maxdepth)
+        flux = self._get_solver().light_curve(s.flux, t, texp, tol, maxdepth)
+
+        # Apply dilution. 0.9 dilution (central is 1/10 of light in aperture)
+        #   will turn 0.9 flux into 0.99
+        flux = 1 - (1 - flux)*(1 - self.dilution)
+
+        return flux
+
 
     def radial_velocity(self, t):
         """

--- a/transit/transit.py
+++ b/transit/transit.py
@@ -349,6 +349,21 @@ class Body(object):
         return math.asin(arg) * self.period / math.pi
 
     @property
+    def duration_approx(self):
+        """Same as duration, but no warning.
+        """
+        self._check_ps()
+        rstar = self.system.central.radius
+        k = self.r/rstar
+        si = math.sin(math.radians(self.incl))
+
+        arg = rstar / self.a * math.sqrt((1+k) ** 2 - self.b**2) / si
+
+        return math.asin(arg) * self.period / math.pi
+
+
+
+    @property
     def e(self):
         return self._e
 

--- a/transit/transit.py
+++ b/transit/transit.py
@@ -210,7 +210,7 @@ class Body(object):
         assert pomega is None or omega is None, \
             "You can't specify omega and pomega"
         if omega is not None:
-            self.omega = omega
+            self.pomega = 0.5 * np.pi - omega
         elif pomega is not None:
             self.pomega = pomega
         else:
@@ -365,7 +365,7 @@ class Body(object):
 
     @omega.setter
     def omega(self, v, hp=0.5*np.pi):
-        self.pomga = v - hp
+        self.pomega = v - hp
 
 
 class System(object):

--- a/transit/transit.py
+++ b/transit/transit.py
@@ -333,7 +333,7 @@ class Body(object):
     def duration(self):
         """
         The approximate duration of the transit :math:`T_\mathrm{tot}` from
-        Equation (14) in Winn (2010).
+        Equations (14), (16) in Winn (2010)
 
         """
         self._check_ps()
@@ -342,11 +342,11 @@ class Body(object):
         si = math.sin(math.radians(self.incl))
         arg = rstar / self.a * math.sqrt((1+k) ** 2 - self.b**2) / si
 
-        if self.e > 0.0:
-            logging.warn("The duration of an eccentric transit isn't analytic."
-                         " Use this value with caution")
+        factor = 1.0
+        if self.e > 0.0: 
+            factor = math.sqrt(1 - e**2) / (1 + e*math.sin(self.omega))
 
-        return math.asin(arg) * self.period / math.pi
+        return math.asin(arg) * self.period / math.pi * factor
 
     @property
     def duration_approx(self):


### PR DESCRIPTION
Sorry for the multiple updates in a single pull request:
- I added a `duration_approx` property that does not throw a warning, and 
- I added  `dilution` as a parameter of a System.  

I may or may not be continuing to update this branch as I work on setting up a generic transit fitter tool using this module, so you can wait to merge if you like. 
